### PR TITLE
리액트 쿼리를 이용해 사이트 초기화에 필요한 정보를 받아오게 고쳤다.

### DIFF
--- a/horror-alram-front/src/App.js
+++ b/horror-alram-front/src/App.js
@@ -1,36 +1,25 @@
 import { BrowserRouter, } from 'react-router-dom'
-import MainTabs from "./components/MainTab.jsx";
+import MainTabs from "./components/MainTab copy.jsx";
 import { createGlobalStyle } from 'styled-components';
 import Footer from './components/Footer.jsx';
-import getUpcomingMovies from './functions/upcoming.js';
-import getExpiringMovies from './functions/expiring.js';
-import getReleasingMovies from './functions/releasing.js';
-import {
-  handleInitialSubscription
-} from "./functions/messaging.js";
+import { QueryClient, QueryClientProvider} from '@tanstack/react-query'
+
 const GlobalStyle = createGlobalStyle`
   body {
     background: #2F4F4F	;
   }
 `;
-
-const upcomingMovies = await getUpcomingMovies();
-const expiringMovies = await getExpiringMovies();
-const releasingMovies = await getReleasingMovies();
-const intialSubscription = await handleInitialSubscription();
-
+const queryClient = new QueryClient()
 function App() {
+
   return (
-    <BrowserRouter>
-      <GlobalStyle />
-      <MainTabs 
-        upcomingMovies={upcomingMovies}
-        streamingMovies={expiringMovies}
-        releasingMovies={releasingMovies}
-        intialSubscription={intialSubscription}
-      />
-      <Footer />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <GlobalStyle />
+        <MainTabs/>
+        <Footer />
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/horror-alram-front/src/App.js
+++ b/horror-alram-front/src/App.js
@@ -1,5 +1,5 @@
 import { BrowserRouter, } from 'react-router-dom'
-import MainTabs from "./components/MainTab copy.jsx";
+import MainTabs from "./components/MainTab.jsx";
 import { createGlobalStyle } from 'styled-components';
 import Footer from './components/Footer.jsx';
 import { QueryClient, QueryClientProvider} from '@tanstack/react-query'

--- a/horror-alram-front/src/components/ImageList.jsx
+++ b/horror-alram-front/src/components/ImageList.jsx
@@ -27,15 +27,25 @@ export default function MovieImageList({ movies, error, handleOpen, guideText })
             {error && <Div>서버 문제로 영화 정보를 가져오지 못했습니다. 다시 시도해주세요.</Div>}
             {!error && movies.length === 0 && <Div>{guideText}</Div>}
             {!error && movies.length > 0 && movies.map((movie) => (
-                <ImageListItem className='image-item' key={movie.id} onClick={() => handleClickOpen(movie)} sx={{ height: 150 }}>
-                    <img src={`${process.env.REACT_APP_POSTER_API_URL}${movie.posterPath}`} alt={movie.title} />
-                    <ImageListItemBar
-                        title={movie.title}
-                        subtitle={movie.releaseDate}
-                        position="overlay"
-                    />
-                </ImageListItem>
+                <>
+                    <ImageListItem className='image-item' key={movie.id} sx={{ height: 150 }}>
+                        <img src={`${process.env.REACT_APP_POSTER_API_URL}${movie.posterPath}`} alt={movie.title} onClick={() => handleClickOpen(movie)} loading="lazy" />
+                        <ImageListItemBar
+                            title={movie.title}
+                            subtitle={movie.releaseDate}
+                            position="overlay"
+                            onClick={() => handleClickOpen(movie)}
+                        />
+                        <ImageListItemBar
+                            sx={{color: 'white'}}
+                            title={movie.theaters.length > 0 ? '상영관' : '상영관 정보 없음'}
+                            subtitle={movie.theaters.length > 0 ? movie.theaters.join(', ') : '상영관 정보 없음'}
+                            position="below"
+                        />
+                    </ImageListItem>
+                </>
             ))}
+
         </ImageList>
     );
 }


### PR DESCRIPTION
기존에 전역에서 모든 데이터를 동기적으로 받아오니 사이트 렌더링 속도가 너무 느리고, useEffect를 이용해 렌더링이 끝난 후 함수를 호출해 값을 받아올 경우 예외시 처리가 힘들어 리액트 쿼리를 이용해 정보를 받아오는 방식으로 고쳤다.